### PR TITLE
Dazfuller/export fixes

### DIFF
--- a/AdxUtils.Export/KustoQuery.cs
+++ b/AdxUtils.Export/KustoQuery.cs
@@ -80,6 +80,7 @@ public class KustoQuery : IDisposable
 
             var ingestValue = value switch
             {
+                sbyte s => s.ToString(),
                 bool b => b ? "1": "0",
                 DateTime dateTime => dateTime.ToString("o"),
                 Guid guid => guid.ToString(),

--- a/AdxUtils.Options/ExportOptions.cs
+++ b/AdxUtils.Options/ExportOptions.cs
@@ -34,7 +34,7 @@ public class ExportOptions : IAuthenticationOptions, IEndpointOptions
     public string ClientSecret { get; set; } = string.Empty;
     
     /// <summary>
-    /// Gets, sets the authority to authenticate agaisnt.
+    /// Gets, sets the authority to authenticate against.
     /// </summary>
     public string Authority { get; set; } = string.Empty;
     
@@ -80,12 +80,12 @@ public class ExportOptions : IAuthenticationOptions, IEndpointOptions
     /// <summary>
     /// Gets the collection of ignored tables as a non-nullable array.
     /// </summary>
-    public IEnumerable<string> IgnoredTablesArray => IgnoredTables?.ToArray() ?? Array.Empty<string>();
+    public IEnumerable<string> IgnoredTablesArray => IgnoredTables?.Select(t => t.Trim()).ToArray() ?? Array.Empty<string>();
 
     /// <summary>
     /// Gets the collection of tables to have their data exported as a non-nullable array.
     /// </summary>
-    public IEnumerable<string> ExportedDataTablesArray => ExportedDataTables?.ToArray() ?? Array.Empty<string>();
+    public IEnumerable<string> ExportedDataTablesArray => ExportedDataTables?.Select(t => t.Trim()).ToArray() ?? Array.Empty<string>();
 
     /// <summary>
     /// Validates the values provided for the export options.


### PR DESCRIPTION
Add the following fixes

* Handling of boolean values which are stored as sbyte values
* Trimming of strings when passed to the cli as ", " separated