### PR TITLE
Cristina/add improvements datatable operator

### DIFF
--- a/AdxUtils.Export.Tests/DatabaseExportTests.cs
+++ b/AdxUtils.Export.Tests/DatabaseExportTests.cs
@@ -146,7 +146,6 @@ public class DatabaseExportTests
             .Select(l => l.Trim())
             .Where(l => !string.IsNullOrEmpty(l))
             .ToList();
-        var temp = result;
 
         result.Should().NotBeEmpty().And.Contain(expected);
     }

--- a/AdxUtils.Export.Tests/DatabaseExportTests.cs
+++ b/AdxUtils.Export.Tests/DatabaseExportTests.cs
@@ -146,6 +146,7 @@ public class DatabaseExportTests
             .Select(l => l.Trim())
             .Where(l => !string.IsNullOrEmpty(l))
             .ToList();
+        var temp = result;
 
         result.Should().NotBeEmpty().And.Contain(expected);
     }
@@ -296,7 +297,7 @@ public class DatabaseExportTests
         var queryService = new Mock<IKustoQuery>();
 
         var table1DataBuilder = new StringBuilder();
-        table1DataBuilder.AppendLine(".ingest inline into table table1_temp <|");
+        table1DataBuilder.AppendLine(".set-or-replace table1 with(policy_ingestiontime = true, distributed = False) <| datatable (col1:string, col2:datetime)");
         table1DataBuilder.AppendLine("\"row1\",2022-10-21T19:21:23.000000");
         table1DataBuilder.AppendLine("\"row2\",2022-10-21T19:22:27.000000");
 

--- a/AdxUtils.Export.Tests/KustoQueryTests.cs
+++ b/AdxUtils.Export.Tests/KustoQueryTests.cs
@@ -115,15 +115,15 @@ public class KustoQueryTests
             ColumnSchema.FromNameAndCslType("col11", "decimal"),
         };
 
-        var sourceTable = new TableSchema("table 1", columns);
-        const string tempTable = "table1_temp";
+        var sourceTable = new TableSchema("table1", columns);
+        const string schema = "col1:string, col2:datetime";
 
         // Execute the method
-        var result = await query.TableDataToCslString(sourceTable, tempTable);
+        var result = await query.TableDataToCslString(sourceTable, schema);
 
         // Assert results
         result.Should().NotBeEmpty()
-            .And.StartWith(".ingest inline into table table1_temp <|")
+            .And.StartWith(".set-or-replace table1")
             .And.ContainAll(expectedExportData);
     }
 }

--- a/AdxUtils.Export.Tests/TestData/SimpleExportIgnoredTable.csl
+++ b/AdxUtils.Export.Tests/TestData/SimpleExportIgnoredTable.csl
@@ -27,10 +27,6 @@ table2
 // Ingest data
 //
 
-.ingest inline into table table1_temp <|
+.set-or-replace table1 with(policy_ingestiontime = true, distributed = False) <| datatable (col1:string, col2:datetime)
 "row1",2022-10-21T19:21:23.000000
 "row2",2022-10-21T19:22:27.000000
-
-.set-or-replace  table1 with(policy_ingestiontime = true, distributed = False) <| table1_temp
-
-.drop table table1_temp ifexists

--- a/AdxUtils.Export.Tests/TestData/SimpleExportRenamedTable.csl
+++ b/AdxUtils.Export.Tests/TestData/SimpleExportRenamedTable.csl
@@ -27,10 +27,6 @@ table1
 // Ingest data
 //
 
-.ingest inline into table table1_temp <|
+.set-or-replace table1 with(policy_ingestiontime = true, distributed = False) <| datatable (col1:string, col2:datetime)
 "row1",2022-10-21T19:21:23.000000
 "row2",2022-10-21T19:22:27.000000
-
-.set-or-replace  table1 with(policy_ingestiontime = true, distributed = False) <| table1_temp
-
-.drop table table1_temp ifexists

--- a/AdxUtils.Export.Tests/TestData/SimpleExportResult.csl
+++ b/AdxUtils.Export.Tests/TestData/SimpleExportResult.csl
@@ -34,10 +34,6 @@ table2
 // Ingest data
 //
 
-.ingest inline into table table1_temp <|
+.set-or-replace table1 with(policy_ingestiontime = true, distributed = False) <| datatable (col1:string, col2:datetime)
 "row1",2022-10-21T19:21:23.000000
 "row2",2022-10-21T19:22:27.000000
-
-.set-or-replace  table1 with(policy_ingestiontime = true, distributed = False) <| table1_temp
-
-.drop table table1_temp ifexists

--- a/AdxUtils.Export.Tests/TestData/SimpleIgnoredFunctionFolder.csl
+++ b/AdxUtils.Export.Tests/TestData/SimpleIgnoredFunctionFolder.csl
@@ -17,10 +17,6 @@
 // Ingest data
 //
 
-.ingest inline into table table1_temp <|
+.set-or-replace table1 with(policy_ingestiontime = true, distributed = False) <| datatable (col1:string, col2:datetime)
 "row1",2022-10-21T19:21:23.000000
 "row2",2022-10-21T19:22:27.000000
-
-.set-or-replace  table1 with(policy_ingestiontime = true, distributed = False) <| table1_temp
-
-.drop table table1_temp ifexists

--- a/AdxUtils.Export.Tests/TestData/SimpleIgnoredFunctions.csl
+++ b/AdxUtils.Export.Tests/TestData/SimpleIgnoredFunctions.csl
@@ -21,11 +21,6 @@ table2
 //
 // Ingest data
 //
-
-.ingest inline into table table1_temp <|
+.set-or-replace table1 with(policy_ingestiontime = true, distributed = False) <| datatable (col1:string, col2:datetime)
 "row1",2022-10-21T19:21:23.000000
 "row2",2022-10-21T19:22:27.000000
-
-.set-or-replace  table1 with(policy_ingestiontime = true, distributed = False) <| table1_temp
-
-.drop table table1_temp ifexists

--- a/AdxUtils.Export/IKustoQuery.cs
+++ b/AdxUtils.Export/IKustoQuery.cs
@@ -1,10 +1,12 @@
 ﻿using Kusto.Data.Common;
+using System.Text;
 
 namespace AdxUtils.Export;
 
 public interface IKustoQuery
 {
-    public Task<string> TableDataToCslString(TableSchema table, string tempTableName);
+    //public Task<string> TableDataToCslString(TableSchema table, string tempTableName);
+    public Task<string> TableDataToCslString(TableSchema table, string queryBuilder);
     Task InsertNewColumnInTable(TableSchema table, string newColumnToInsert, string columnType);
     Task DropColumnInTable(TableSchema table, string columnToDrop);
 }

--- a/AdxUtils.Export/KustoQuery.cs
+++ b/AdxUtils.Export/KustoQuery.cs
@@ -34,11 +34,11 @@ public class KustoQuery : IKustoQuery
 
         queryBuilder.AppendLine($".set-or-replace {table.Name}");
         queryBuilder.AppendLine($"with(policy_ingestiontime = true, distributed = False) <| datatable ({schema})");
-        foreach (var record in tableData)
-        {
-            queryBuilder.AppendLine(record);
-        }
-
+        queryBuilder.AppendLine("[");
+        List<string> records = tableData.ToList();
+        string formattedListWithComma = string.Join(", \n",records);
+        queryBuilder.AppendLine(formattedListWithComma);
+        queryBuilder.AppendLine("]");
         return queryBuilder.ToString();
     }
 

--- a/AdxUtils.Export/KustoQuery.cs
+++ b/AdxUtils.Export/KustoQuery.cs
@@ -23,7 +23,7 @@ public class KustoQuery : IKustoQuery
         _adminProvider = adminProvider;
     }
 
-    public async Task<string> TableDataToCslString(TableSchema table, string tempTableName)
+    public async Task<string> TableDataToCslString(TableSchema table, string schema)
     {
         var queryBuilder = new StringBuilder();
 
@@ -31,8 +31,9 @@ public class KustoQuery : IKustoQuery
         var tableData = await GetTableData(table);
 
         if (!tableData.Any()) return string.Empty;
-        
-        queryBuilder.AppendLine($".ingest inline into table {CslSyntaxGenerator.NormalizeTableName(tempTableName)} <|");
+
+        queryBuilder.AppendLine($".set-or-replace {table.Name}");
+        queryBuilder.AppendLine($"with(policy_ingestiontime = true, distributed = False) <| datatable ({schema})");
         foreach (var record in tableData)
         {
             queryBuilder.AppendLine(record);

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The app can currently use either Client Secret Key authentication, or Azure CLI 
 
 ## Export
 
-This is the first of the utilities developed which automates the generation of a CSL script for a given database. The script contains the commands needed to re-create the tables and functions, along with mapping information. It also supports renaming of tables and the ability to copy data using an `.ingest inline` command. The generated output is intended to work with the [Azure DevOps Task for Data Explorer](https://learn.microsoft.com/azure/data-explorer/devops) where the commands are split based on empty lines and executed individually against the target database. The generated script can just as easily be executed directly by using an `.execute database script`.
+This is the first of the utilities developed which automates the generation of a CSL script for a given database. The script contains the commands needed to re-create the tables and functions, along with mapping information. It also supports renaming of tables and the ability to copy data using an `.set-or-replace` command with `datatable` operator. The generated output is intended to work with the [Azure DevOps Task for Data Explorer](https://learn.microsoft.com/azure/data-explorer/devops) where the commands are split based on empty lines and executed individually against the target database. The generated script can just as easily be executed directly by using an `.execute database script`.
 
 An example usage of the command is
 


### PR DESCRIPTION
_In order to implement the following user history, this PR is added._ 

_As a software engineer
I want to use ADX utils tool to execute different operations on the ADX databases
So there is not an intermittent issue during the use of the tool._



Example of new script to generate:
```
.create-merge table UserRoleDefinitionsCristina (Section:string, Admin:bool, Contributor:bool, Viewer:bool, Reporter:bool, GlobalAdmin:bool)
.alter table UserRoleDefinitionsCristina policy ingestiontime true
 
.set-or-replace  UserRoleDefinitionsCristina with(policy_ingestiontime = true, distributed = False) <| datatable  (Section:string, Admin:bool, Contributor:bool, Viewer:bool, Reporter:bool, GlobalAdmin:bool)
["ColorizationRules",1,1,0,0,1,
"BimStore",1,1,1,0,1,
"HistoricQuery",1,1,0,0,1,
"publicPages",1,1,1,1,1,
"analytics",1,1,1,1,1,
"geo",1,1,1,0,1,
"HistoricAlerts",1,1,1,0,1,
"AnalyticsPack",1,1,1,0,1,
"AnalyticsAlerts",1,1,0,0,1,
"DistributionGroups",1,1,0,0,1,
"CreateBuilding",1,1,0,0,1,
"edit",1,1,0,0,1,
"sensorManagement",1,1,0,0,1,
"modelManagement",1,1,0,0,1,
"wayFindPaths",1,1,1,1,1,
"CreateCompany",0,0,0,0,1,
"CompanyManagement",0,0,0,0,1,
"BillingPage",0,0,0,0,1,
"UserManagement",1,1,0,0,1,
"RulesManagement",1,1,0,0,1,
"CdeCollectionSchedule",1,1,0,0,1,
"CreateProject",1,1,0,0,1]

```
